### PR TITLE
Fixing issue #6 (Failed user's hooks break RP integration)

### DIFF
--- a/src/ReportPortal.SpecFlowPlugin/Plugin.cs
+++ b/src/ReportPortal.SpecFlowPlugin/Plugin.cs
@@ -1,4 +1,5 @@
 ﻿using ReportPortal.SpecFlowPlugin;
+using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Plugins;
 using TechTalk.SpecFlow.Tracing;
 
@@ -17,6 +18,11 @@ namespace ReportPortal.SpecFlowPlugin
                 runtimePluginEvents.CustomizeTestThreadDependencies += (sender, e) =>
                 {
                     e.ObjectContainer.RegisterTypeAs<ReportPortalAddin, ITestTracer>();
+                };
+
+                runtimePluginEvents.CustomizeGlobalDependencies += (sender, e) =>
+                {
+                    e.ObjectContainer.RegisterTypeAs<SafeBindingInvoker, IBindingInvoker>();
                 };
             }
         }

--- a/src/ReportPortal.SpecFlowPlugin/ReportPortal.SpecFlowPlugin.csproj
+++ b/src/ReportPortal.SpecFlowPlugin/ReportPortal.SpecFlowPlugin.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="ReportPortalAddin.cs" />
+    <Compile Include="SafeBindingInvoker.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/ReportPortal.SpecFlowPlugin/ReportPortalAddin.cs
+++ b/src/ReportPortal.SpecFlowPlugin/ReportPortalAddin.cs
@@ -44,7 +44,7 @@ namespace ReportPortal.SpecFlowPlugin
         public static event RunStartedHandler BeforeRunStarted;
         public static event RunStartedHandler AfterRunStarted;
 
-        [BeforeTestRun]
+        [BeforeTestRun(Order = -20000)]
         public static void BeforeTestRun()
         {
             if (Configuration.ReportPortal.Enabled)
@@ -75,7 +75,7 @@ namespace ReportPortal.SpecFlowPlugin
         public static event RunFinishedHandler BeforeRunFinished;
         public static event RunFinishedHandler AfterRunFinished;
 
-        [AfterTestRun]
+        [AfterTestRun(Order = 20000)]
         public static void AfterTestRun()
         {
             if (Bridge.Context.LaunchId != null)
@@ -102,7 +102,7 @@ namespace ReportPortal.SpecFlowPlugin
         public static event FeatureStartedHandler BeforeFeatureStarted;
         public static event FeatureStartedHandler AfterFeatureStarted;
 
-        [BeforeFeature]
+        [BeforeFeature(Order = -20000)]
         public static void BeforeFeature()
         {
             if (Bridge.Context.LaunchId != null)
@@ -133,7 +133,7 @@ namespace ReportPortal.SpecFlowPlugin
         public static event FeatureFinishedHandler BeforeFeatureFinished;
         public static event FeatureFinishedHandler AfterFeatureFinished;
 
-        [AfterFeature]
+        [AfterFeature(Order = 20000)]
         public static void AfterFeature()
         {
             if (CurrentFeatureId != null)
@@ -160,7 +160,7 @@ namespace ReportPortal.SpecFlowPlugin
         public static event ScenarioStartedHandler BeforeScenarioStarted;
         public static event ScenarioStartedHandler AfterScenarioStarted;
 
-        [BeforeScenario]
+        [BeforeScenario(Order = -20000)]
         public void BeforeScenario()
         {
             if (CurrentFeatureId != null)
@@ -198,7 +198,7 @@ namespace ReportPortal.SpecFlowPlugin
 
         private static Status Status = Status.Passed;
 
-        [AfterScenario]
+        [AfterScenario(Order = 20000)]
         public void AfterScenario()
         {
             if (CurrentScenarioId != null)

--- a/src/ReportPortal.SpecFlowPlugin/SafeBindingInvoker.cs
+++ b/src/ReportPortal.SpecFlowPlugin/SafeBindingInvoker.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using TechTalk.SpecFlow;
+using TechTalk.SpecFlow.Bindings;
+using TechTalk.SpecFlow.Configuration;
+using TechTalk.SpecFlow.ErrorHandling;
+using TechTalk.SpecFlow.Infrastructure;
+using TechTalk.SpecFlow.Tracing;
+
+namespace ReportPortal.SpecFlowPlugin
+{
+    public class SafeBindingInvoker : BindingInvoker
+    {
+        public SafeBindingInvoker(RuntimeConfiguration runtimeConfiguration, IErrorProvider errorProvider)
+            : base(runtimeConfiguration, errorProvider)
+        {
+        }
+
+        public override object InvokeBinding(IBinding binding, IContextManager contextManager, object[] arguments,
+            ITestTracer testTracer, out TimeSpan duration)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            try
+            {
+                return base.InvokeBinding(binding, contextManager, arguments,
+                    testTracer, out duration);
+            }
+            catch (Exception ex)
+            {
+                PreserveStackTrace(ex);
+
+                if (binding is IHookBinding == false)
+                {
+                    throw;
+                }
+
+                var hookBinding = binding as IHookBinding;
+
+                if (hookBinding.HookType == HookType.BeforeScenario
+                    || hookBinding.HookType == HookType.BeforeScenarioBlock
+                    || hookBinding.HookType == HookType.BeforeScenario
+                    || hookBinding.HookType == HookType.BeforeStep
+                    || hookBinding.HookType == HookType.AfterStep
+                    || hookBinding.HookType == HookType.AfterScenario
+                    || hookBinding.HookType == HookType.AfterScenarioBlock)
+                {
+                    testTracer.TraceError(ex);
+                    SetTestError(contextManager.ScenarioContext, ex);
+                }
+            }
+            finally
+            {
+                stopwatch.Stop();
+
+                duration = stopwatch.Elapsed;
+            }
+
+            return new object();
+        }
+
+        private static void SetTestError(ScenarioContext context, Exception ex)
+        {
+            if (context != null && context.TestError == null)
+            {
+                context.GetType().GetProperty("TestStatus", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SetValue(context, TestStatus.TestError);
+
+                context.GetType().GetProperty("TestError")
+                    .SetValue(context, ex);
+            }
+        }
+
+        private static void PreserveStackTrace(Exception ex)
+        {
+            typeof(Exception).GetMethod("InternalPreserveStackTrace", BindingFlags.Instance | BindingFlags.NonPublic).Invoke(ex, new object[0]);
+        }
+    }
+}


### PR DESCRIPTION
The pull request will resolve #6. But the changes are controversial ones since they change standard specflow behavior - consequent hooks will be executed even if previous one failed. It was done in order to guarantee that Report Portal hooks will be executed under any circumstances.

Exceptions in BeforeTestRun, BeforeFeature, AfterFeature, and AfterTestRun hooks will be ignored since there is no scenario to log failure under. Exceptions from all other hooks will be correctly logged under scenario.

Please let me know if I should enhance the implementation. The following improvement can be made:
- Not to ignore BeforeTestRun and BeforeFeature failures but rather fail all scenarios. I still will not be able to log exceptions from AfterFeature and AfterTestRun.
- Run only RP integration hooks if one of previous hooks failed.

PS: AfterXxx hooks now have 20000 order since the default order is 10000 and we want to run RP hooks after all others. BeforeXxx hooks have -20000 because 0+ is often used within tests themselves and -20000 is symmetric to 20000.