### PR TITLE
Add possibility for storing config options in app.config of current project

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ After installing NuGet package your App.config is modified. Report Portal plugin
 # Configuration
 All settings are stored in *ReportPortal.SpecFlowPlugin.dll.config* file which was added into your project by nuget installation.
 
-
 Example of config file:
 ```xml
 <configuration>
@@ -40,3 +39,6 @@ Example of config file:
   </reportPortal>
 </configuration>
 ```
+
+Alternatively,you could configure the plugin via app.config of your application, instead of *ReportPortal.SpecFlowPlugin.dll.config*.Just add above mentioned config 
+options to app.config and remove *ReportPortal.SpecFlowPlugin.dll.config*.

--- a/src/ReportPortal.SpecFlowPlugin/Configuration.cs
+++ b/src/ReportPortal.SpecFlowPlugin/Configuration.cs
@@ -5,17 +5,31 @@ namespace ReportPortal.SpecFlowPlugin
 {
     public static class Configuration
     {
-        static readonly ReportPortalSection ReportPortalSection;
+        static readonly Lazy<ReportPortalSection> ReportPortalSection = new Lazy<ReportPortalSection>(() => LoadConfigurationFromPluginAssembly() ?? LoadConfigurationFromAssemblyThatUsingThePlugin());
 
-        static Configuration()
+        private static ReportPortalSection LoadConfigurationFromAssemblyThatUsingThePlugin()
+        {
+            return ConfigurationManager.GetSection("reportPortal") as ReportPortalSection;
+        }
+
+        private static ReportPortalSection LoadConfigurationFromPluginAssembly()
         {
             var exeConfigPath = new Uri(typeof(Configuration).Assembly.CodeBase).LocalPath;
-            ReportPortalSection = ConfigurationManager.OpenExeConfiguration(exeConfigPath).GetSection("reportPortal") as ReportPortalSection;
+            return ConfigurationManager.OpenExeConfiguration(exeConfigPath).GetSection("reportPortal") as ReportPortalSection;
+        }
+
+        private static void ThrowAnErrorIfReportalPortalConfigurationSectionIsNull()
+        {
+            if (ReportPortalSection.Value == null)
+                throw new ConfigurationErrorsException("No ReportPortalSection in config file!");
         }
 
         public static ReportPortalSection ReportPortal
         {
-            get { return ReportPortalSection; }
+            get {
+                    ThrowAnErrorIfReportalPortalConfigurationSectionIsNull();
+                    return ReportPortalSection.Value; 
+                }
         }
     }
 

--- a/src/ReportPortal.SpecFlowPlugin/EventArguments/RunFinishedEventArgs.cs
+++ b/src/ReportPortal.SpecFlowPlugin/EventArguments/RunFinishedEventArgs.cs
@@ -14,11 +14,11 @@ namespace ReportPortal.SpecFlowPlugin.EventArguments
             LaunchReporter = launchReporter;
         }
 
-        public Service Service { get; }
+        public Service Service { get; private set; }
 
-        public FinishLaunchRequest Launch { get; }
+        public FinishLaunchRequest Launch { get; private set; }
 
-        public LaunchReporter LaunchReporter { get; }
+        public LaunchReporter LaunchReporter { get; private set; }
 
         public bool Canceled { get; set; }
     }

--- a/src/ReportPortal.SpecFlowPlugin/EventArguments/RunStartedEventArgs.cs
+++ b/src/ReportPortal.SpecFlowPlugin/EventArguments/RunStartedEventArgs.cs
@@ -19,11 +19,11 @@ namespace ReportPortal.SpecFlowPlugin.EventArguments
             LaunchReporter = launchReporter;
         }
 
-        public Service Service { get; }
+        public Service Service { get; private set; }
 
-        public StartLaunchRequest Launch { get; }
+        public StartLaunchRequest Launch { get; private set; }
 
-        public LaunchReporter LaunchReporter { get; }
+        public LaunchReporter LaunchReporter { get; private set; }
 
         public bool Canceled { get; set; }
     }

--- a/src/ReportPortal.SpecFlowPlugin/EventArguments/TestItemFinishedEventArgs.cs
+++ b/src/ReportPortal.SpecFlowPlugin/EventArguments/TestItemFinishedEventArgs.cs
@@ -14,11 +14,11 @@ namespace ReportPortal.SpecFlowPlugin.EventArguments
             TestReporter = testReporter;
         }
 
-        public Service Service { get; }
+        public Service Service { get; private set; }
 
-        public FinishTestItemRequest TestItem { get; }
+        public FinishTestItemRequest TestItem { get; private set; }
 
-        public TestReporter TestReporter { get; }
+        public TestReporter TestReporter { get; private set; }
 
         public bool Canceled { get; set; }
     }

--- a/src/ReportPortal.SpecFlowPlugin/EventArguments/TestItemStartedEventArgs.cs
+++ b/src/ReportPortal.SpecFlowPlugin/EventArguments/TestItemStartedEventArgs.cs
@@ -19,12 +19,12 @@ namespace ReportPortal.SpecFlowPlugin.EventArguments
             TestReporter = testReporter;
         }
 
-        public Service Service { get; }
+        public Service Service { get; private set; }
 
-        public StartTestItemRequest TestItem { get; }
+        public StartTestItemRequest TestItem { get; private set; }
 
-        public TestReporter TestReporter { get; }
+        public TestReporter TestReporter { get; private set; }
 
-        public bool Canceled { get; set; }
+        public bool Canceled { get; set;}
     }
 }


### PR DESCRIPTION
We faced with a problem that our test project is configure via app.config and it would be great to have possibility to configure reportportal-net-agent via app.config, as we run our tests on different envs, we use transformation to change app.config for different envs.