### PR TITLE
Resolving issue when the plugin swallowed exceptions in test run and feature hooks

### DIFF
--- a/src/ReportPortal.SpecFlowPlugin/ReportPortalHooks.cs
+++ b/src/ReportPortal.SpecFlowPlugin/ReportPortalHooks.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using ReportPortal.Client.Models;
 using ReportPortal.Client.Requests;
 using ReportPortal.Shared;
@@ -38,7 +39,6 @@ namespace ReportPortal.SpecFlowPlugin
                     Bridge.Context.LaunchReporter = new LaunchReporter(Bridge.Service);
 
                     Bridge.Context.LaunchReporter.Start(request);
-                    Bridge.Context.LaunchReporter.StartTask.Wait();
 
                     ReportPortalAddin.OnAfterRunStarted(null, new RunStartedEventArgs(Bridge.Service, request, Bridge.Context.LaunchReporter));
                 }
@@ -61,7 +61,14 @@ namespace ReportPortal.SpecFlowPlugin
                 if (!eventArg.Canceled)
                 {
                     Bridge.Context.LaunchReporter.Finish(request);
-                    Bridge.Context.LaunchReporter.FinishTask.Wait();
+                    try
+                    {
+                        Bridge.Context.LaunchReporter.FinishTask.Wait();
+                    }
+                    catch(Exception exp)
+                    {
+                        File.AppendAllText("ReportPortal.Errors.log", exp.ToString());
+                    }
 
                     ReportPortalAddin.OnAfterRunFinished(null, new RunFinishedEventArgs(Bridge.Service, request, Bridge.Context.LaunchReporter));
                 }
@@ -129,7 +136,6 @@ namespace ReportPortal.SpecFlowPlugin
                     if (!eventArg.Canceled)
                     {
                         currentFeature.Finish(request);
-                        currentFeature.FinishTask.Wait();
 
                         ReportPortalAddin.OnAfterFeatureFinished(null, new TestItemFinishedEventArgs(Bridge.Service, request, currentFeature));
                     }
@@ -253,7 +259,6 @@ namespace ReportPortal.SpecFlowPlugin
                 if (!eventArg.Canceled)
                 {
                     currentScenario.Finish(request);
-                    currentScenario.FinishTask.Wait();
 
                     ReportPortalAddin.OnAfterScenarioFinished(this, new TestItemFinishedEventArgs(Bridge.Service, request, currentScenario));
                 }

--- a/src/ReportPortal.SpecFlowPlugin/SafeBindingInvoker.cs
+++ b/src/ReportPortal.SpecFlowPlugin/SafeBindingInvoker.cs
@@ -25,34 +25,30 @@ namespace ReportPortal.SpecFlowPlugin
 
             try
             {
-                return base.InvokeBinding(binding, contextManager, arguments,
-                    testTracer, out duration);
+                return base.InvokeBinding(binding, contextManager, arguments, testTracer, out duration);
             }
             catch (Exception ex)
             {
                 PreserveStackTrace(ex);
 
-                if (binding is IHookBinding == false)
+                var hookBinding = binding as IHookBinding;
+
+                if (hookBinding == null)
                 {
                     throw;
                 }
-
-                var hookBinding = binding as IHookBinding;
-
-                if (hookBinding.HookType == HookType.BeforeScenario
+                else {
+                    if (hookBinding.HookType == HookType.BeforeScenario
                     || hookBinding.HookType == HookType.BeforeScenarioBlock
                     || hookBinding.HookType == HookType.BeforeScenario
                     || hookBinding.HookType == HookType.BeforeStep
                     || hookBinding.HookType == HookType.AfterStep
                     || hookBinding.HookType == HookType.AfterScenario
                     || hookBinding.HookType == HookType.AfterScenarioBlock)
-                {
-                    testTracer.TraceError(ex);
-                    SetTestError(contextManager.ScenarioContext, ex);
-                }
-                else
-                {
-                    throw;
+                    {
+                        testTracer.TraceError(ex);
+                        SetTestError(contextManager.ScenarioContext, ex);
+                    }
                 }
             }
             finally

--- a/src/ReportPortal.SpecFlowPlugin/SafeBindingInvoker.cs
+++ b/src/ReportPortal.SpecFlowPlugin/SafeBindingInvoker.cs
@@ -50,6 +50,10 @@ namespace ReportPortal.SpecFlowPlugin
                     testTracer.TraceError(ex);
                     SetTestError(contextManager.ScenarioContext, ex);
                 }
+                else
+                {
+                    throw;
+                }
             }
             finally
             {


### PR DESCRIPTION
Resolves #27. SafeBindingInvoker swallowed exceptions in BeforeTestRun, BeforeFeature, AfterFeature, and AfterTestRun hooks.