### PR TITLE
Create ReportPortal.log under assembly directory 

### DIFF
--- a/ReportPortal.SpecFlowPlugin/ReportPortalHooks.cs
+++ b/ReportPortal.SpecFlowPlugin/ReportPortalHooks.cs
@@ -63,18 +63,18 @@ namespace ReportPortal.SpecFlowPlugin
                 {
                     Bridge.Context.LaunchReporter.Finish(request);
 
-                    string lofFile = "ReportPortal.log";
+                    var logFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ReportPortal.log");
                     try
                     {
                         var sw = Stopwatch.StartNew();
 
-                        File.AppendAllText(lofFile, $"Finishing to send results to ReportPortal...{Environment.NewLine}");
+                        File.AppendAllText(logFile, $"Finishing to send results to ReportPortal...{Environment.NewLine}");
                         Bridge.Context.LaunchReporter.FinishTask.Wait();
-                        File.AppendAllText(lofFile, $"Elapsed: {sw.Elapsed}{Environment.NewLine}");
+                        File.AppendAllText(logFile, $"Elapsed: {sw.Elapsed}{Environment.NewLine}");
                     }
                     catch (Exception exp)
                     {
-                        File.AppendAllText(lofFile, $"{exp}{Environment.NewLine}");
+                        File.AppendAllText(logFile, $"{exp}{Environment.NewLine}");
                     }
 
                     ReportPortalAddin.OnAfterRunFinished(null, new RunFinishedEventArgs(Bridge.Service, request, Bridge.Context.LaunchReporter));


### PR DESCRIPTION
The launch will not finish when the running process doesn't have access to the currently directory which can be the home directory of test runner. It's safer to write to directory with tests.

![image](https://user-images.githubusercontent.com/6681200/46121523-0d9d9180-c1e2-11e8-8691-c754a86ac521.png)
