### PR TITLE
Ability for the consumer to provide LaunchReporter

### DIFF
--- a/ReportPortal.SpecFlowPlugin/EventArguments/RunStartedEventArgs.cs
+++ b/ReportPortal.SpecFlowPlugin/EventArguments/RunStartedEventArgs.cs
@@ -23,7 +23,7 @@ namespace ReportPortal.SpecFlowPlugin.EventArguments
 
         public StartLaunchRequest Launch { get; }
 
-        public LaunchReporter LaunchReporter { get; }
+        public LaunchReporter LaunchReporter { get; set; }
 
         public bool Canceled { get; set; }
     }

--- a/ReportPortal.SpecFlowPlugin/ReportPortalHooks.cs
+++ b/ReportPortal.SpecFlowPlugin/ReportPortalHooks.cs
@@ -35,9 +35,14 @@ namespace ReportPortal.SpecFlowPlugin
                 var eventArg = new RunStartedEventArgs(Bridge.Service, request);
                 ReportPortalAddin.OnBeforeRunStarted(null, eventArg);
 
+                if (eventArg.LaunchReporter != null)
+                {
+                    Bridge.Context.LaunchReporter = eventArg.LaunchReporter;
+                }
+
                 if (!eventArg.Canceled)
                 {
-                    Bridge.Context.LaunchReporter = new LaunchReporter(Bridge.Service);
+                    Bridge.Context.LaunchReporter = Bridge.Context.LaunchReporter ?? new LaunchReporter(Bridge.Service);
 
                     Bridge.Context.LaunchReporter.Start(request);
 


### PR DESCRIPTION
Ability for the consumer to provide LaunchReporter (e.g. one that was created for already existing launch).
Currently you can't cancel launch creating and have RP integration at the same time.