### PR TITLE
Remove reporters from tree when finishing

### DIFF
--- a/ReportPortal.SpecFlowPlugin.Tests/ReportPortal.config.json
+++ b/ReportPortal.SpecFlowPlugin.Tests/ReportPortal.config.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "ReportPortal.config.schema",
-  "enabled": false,
+  "enabled": true,
   "server": {
     "url": "https://rp.epam.com/api/v1/",
     "project": "default_project",

--- a/ReportPortal.SpecFlowPlugin/ReportPortalAddin.cs
+++ b/ReportPortal.SpecFlowPlugin/ReportPortalAddin.cs
@@ -36,6 +36,11 @@ namespace ReportPortal.SpecFlowPlugin
             FeatureThreadCount[context.FeatureInfo] = 1;
         }
 
+        internal static void RemoveFeatureTestReporter(FeatureContext context, ITestReporter reporter)
+        {
+            FeatureTestReporters.TryRemove(context.FeatureInfo, out reporter);
+        }
+
         internal static int IncrementFeatureThreadCount(FeatureContext context)
         {
             return FeatureThreadCount[context.FeatureInfo]
@@ -56,6 +61,11 @@ namespace ReportPortal.SpecFlowPlugin
         internal static void SetScenarioTestReporter(ScenarioContext context, ITestReporter reporter)
         {
             ScenarioTestReporters[context.ScenarioInfo] = reporter;
+        }
+
+        internal static void RemoveScenarioTestReporter(ScenarioContext context, ITestReporter reporter)
+        {
+            ScenarioTestReporters.TryRemove(context.ScenarioInfo, out reporter);
         }
 
         public delegate void InitializingHandler(object sender, InitializingEventArgs e);

--- a/ReportPortal.SpecFlowPlugin/ReportPortalAddin.cs
+++ b/ReportPortal.SpecFlowPlugin/ReportPortalAddin.cs
@@ -39,7 +39,7 @@ namespace ReportPortal.SpecFlowPlugin
         internal static void RemoveFeatureTestReporter(FeatureContext context, ITestReporter reporter)
         {
             FeatureTestReporters.TryRemove(context.FeatureInfo, out reporter);
-            FeatureThreadCount[context.FeatureInfo] -= 1;
+            FeatureThreadCount.TryRemove(context.FeatureInfo, out int count);
         }
 
         internal static int IncrementFeatureThreadCount(FeatureContext context)

--- a/ReportPortal.SpecFlowPlugin/ReportPortalAddin.cs
+++ b/ReportPortal.SpecFlowPlugin/ReportPortalAddin.cs
@@ -39,6 +39,7 @@ namespace ReportPortal.SpecFlowPlugin
         internal static void RemoveFeatureTestReporter(FeatureContext context, ITestReporter reporter)
         {
             FeatureTestReporters.TryRemove(context.FeatureInfo, out reporter);
+            FeatureThreadCount[context.FeatureInfo] -= 1;
         }
 
         internal static int IncrementFeatureThreadCount(FeatureContext context)

--- a/ReportPortal.SpecFlowPlugin/ReportPortalHooks.cs
+++ b/ReportPortal.SpecFlowPlugin/ReportPortalHooks.cs
@@ -196,6 +196,8 @@ namespace ReportPortal.SpecFlowPlugin
                         ReportPortalAddin.OnAfterFeatureFinished(null, new TestItemFinishedEventArgs(Bridge.Service, request, currentFeature, featureContext, null));
                     }
                 }
+
+                ReportPortalAddin.RemoveFeatureTestReporter(featureContext, currentFeature);
             }
         }
 
@@ -325,6 +327,8 @@ namespace ReportPortal.SpecFlowPlugin
                     currentScenario.Finish(request);
 
                     ReportPortalAddin.OnAfterScenarioFinished(this, new TestItemFinishedEventArgs(Bridge.Service, request, currentScenario, this.FeatureContext, this.ScenarioContext));
+
+                    ReportPortalAddin.RemoveScenarioTestReporter(this.ScenarioContext, currentScenario);
                 }
             }
         }


### PR DESCRIPTION
Just to allow TestReporters to be garbage collected.